### PR TITLE
checkbox to capture and discard basemap

### DIFF
--- a/entity-traffic/graph.html
+++ b/entity-traffic/graph.html
@@ -22,6 +22,9 @@
   <div id="detail"></div>
   <div id="scale"></div>
 
+  <input id="basemap" type="checkbox"></input><label for="network">Basemap</label>
+  <div id="base"></div>
+
   <script type=module>
   const SERVICE = 1
   const NETWORK = 2
@@ -131,6 +134,20 @@
       }
       service.model = {}
       service.label = {}
+    })
+  }
+  for (let checkbox of [basemap]) {
+    checkbox.addEventListener("change", (e) => {
+      if (e.target.id == "basemap") {
+        if (e.target.checked) {
+          let rows = Object.keys(service.model).sort()
+          let edges = rows.map(thing => `${thing}`)
+          let dot = `digraph { rankdir=LR; node [shape=box style=filled fillcolor=bisque]; \n${edges.join("\n")} }`
+          hpccWasm.graphviz.layout(dot, "svg", "dot").then(svg => {base.innerHTML = svg})
+        } else {
+          base.innerHTML = ''
+        }
+      }
     })
   }
 


### PR DESCRIPTION
I've added the ability to freeze a diagram as a basemap upon which further animation can be rendered with d3 or three.js.

Here I configured one view into the system, captured it as a base map, then changed the original view for comparison.
I omit numbers on the basemap because I expect traffic to be animated with dots flying with each message.

![image](https://user-images.githubusercontent.com/12127/106516743-5ccbef00-648c-11eb-895c-f423f5c7808c.png)
