### PR TITLE
Dynamic bricks

### DIFF
--- a/entity-traffic/graph.html
+++ b/entity-traffic/graph.html
@@ -109,6 +109,7 @@
     }
 
     harvest() {
+      if(basemap.checked) return
       let rows = Object.keys(this.model).sort()
       //display("chart", abstract(rows, 'balancer').map(thing => `${thing} [label="${label[thing]||model[thing]}"]`))
       //rows = rows.filter((k) => !k.startsWith("user ->"))
@@ -125,7 +126,10 @@
 
   let service = new View("chart", "gold")
   start(
-    (...args) => service.log(...args)
+    (...args) => {
+      service.log(...args)
+      if (basemap.checked) tilt.log(...args)
+    }
   )
 
   function abstract(rows, detail) {

--- a/entity-traffic/objsim.js
+++ b/entity-traffic/objsim.js
@@ -24,15 +24,12 @@ function start(model_logger) {
   log = model_logger
   for (let name of ['Joshua', 'Beth', 'Ward', 'Eric']) {
       let user = new User(name)
-      user.host = new Host(`${name}_host`)
+      user.host = new Host(`gateway`)
       user.run()
   }
   for (let vendor of ['amazon', 'apple', 'shopify']) {
       let source = new Source(vendor)
-      source.host = new Host(`${vendor}_host`)
-      source.run()
-      source = new Source(vendor)
-      source.host = new Host(`${vendor}_host`)
+      source.host = new Host(`gateway`)
       source.run()
   }
 }

--- a/entity-traffic/tilt.js
+++ b/entity-traffic/tilt.js
@@ -14,7 +14,8 @@ function start (div, svg) {
 }
 
 function log (level, current, packet) {
-  update (current)
+  discover ([current.instanceName, current.serviceName, current.host.hostname])
+  discover ([packet.prevHop.instanceName, packet.prevHop.serviceName, packet.prevHop.host.hostname])
 }
 
 
@@ -66,20 +67,23 @@ let mat = new THREE.MeshStandardMaterial({
     transparent: true,
   })
 
-function update (current) {
+function discover (aliases) {
   const at = xy => [(xy.x-dim[0]/2)/100, (-xy.y-dim[1]/2)/100]
-  const brick = height => {
+  const brick = (what, height) => {
     let dot = new THREE.Mesh(geo, mat)
-    let p = new THREE.Vector3(...at(nodes[n]), height)
+    let p = new THREE.Vector3(...at(nodes[what]), height)
     dot.position.copy(p)
     scene.add(dot)
   }
-
-  let names = [current.serviceName, current.instanceName, current.host.hostname]
-  let n = names.filter(name => nodes[name])[0]
-  if (!n || nodes[n].showing) return
-  nodes[n].showing = true
-  brick(.3)
+  // what is in the diagram
+  let what = aliases.filter(name => nodes[name])[0]
+  if (!what) return
+  let stack = nodes[what].stack = nodes[what].stack || []
+  // who is in the stack
+  let who = aliases[0]
+  if (stack.includes(who)) return
+  stack.push(who)
+  brick(what, .1 + .2 * stack.length)
 }
 
 


### PR DESCRIPTION
We now discover if bricks have an instance specific place in the diagram or need to stack up over some abstraction. The possibilities appear in our log as one or more aliases. This depends on unique names, not the presence of numbers.

We repeat the discovery process for current nodes and the previous hop, both parties to a transmission. This way we notice users when their traffic arrives at a webserver.

To make a more interesting case we identify the host for all inputs as the cdn-gateway. This makes for a rather tall stack.

![image](https://user-images.githubusercontent.com/12127/110555308-39cad580-80f1-11eb-86f7-6cdab86f8b4b.png)
